### PR TITLE
Fix typo in multi-clause example

### DIFF
--- a/README.md
+++ b/README.md
@@ -418,7 +418,7 @@ ___
       expected result...   
   """
   def update(%Product{count: nil, material: material})
-    when name in ["metal", "glass"] do
+    when material in ["metal", "glass"] do
     # ...
   end
 


### PR DESCRIPTION
Just a small typo. With a cat tax for your effort. 

![A-sad-orange-ginger-cat-with-human-holding jpg optimal](https://user-images.githubusercontent.com/7713/160471023-18759dc8-9b5d-48fd-b591-98b79331aa66.jpg)

